### PR TITLE
Add new vault events & index tracking

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -78,7 +78,7 @@ type CollectionVault @entity(immutable: false) {
   vault: Vault! # The specific vault this configuration and state applies to
   principalShares: BigInt! # Total shares of this collection in this vault (e.g., cTokens)
   principalDeposited: BigInt! # Total amount of underlying asset deposited for this collection in this vault
-  cTokenAmount: BigInt! # Total cTokens issued for this collection in this vault
+  totalCTokens: BigInt! # Total cTokens issued for this collection in this vault
   globalDepositIndex: BigInt! # Global deposit index for yield tracking
   lastGlobalDepositIndex: BigInt! # Last recorded global deposit index
   yieldAccrued: BigInt! # Total yield accrued for this collection

--- a/src/utils/getters.ts
+++ b/src/utils/getters.ts
@@ -120,7 +120,7 @@ export function getOrCreateCollectionVault(
     cv.vault = vault.id;
     cv.principalShares = ZERO_BI;
     cv.principalDeposited = ZERO_BI;
-    cv.cTokenAmount = ZERO_BI;
+    cv.totalCTokens = ZERO_BI;
     cv.globalDepositIndex = ZERO_BI;
     cv.lastGlobalDepositIndex = ZERO_BI;
     cv.yieldAccrued = ZERO_BI;


### PR DESCRIPTION
## Summary
- update CollectionVault total cToken field naming
- store yield accrual indexes on CollectionVault
- support YieldBatchRepaid by recording a SubsidyTransaction

## Testing
- `yarn codegen`
- `yarn test` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684af3ec57d48320bb1fc3e93f3c15a1