### PR TITLE
Add EpochProcessingStarted handler

### DIFF
--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -47,6 +47,8 @@ dataSources:
       eventHandlers:
         - event: EpochStarted(indexed uint256,uint256,uint256)
           handler: handleEpochStarted
+        - event: EpochProcessingStarted(indexed uint256)
+          handler: handleEpochProcessingStarted
         - event: EpochFinalized(indexed uint256,uint256,uint256)
           handler: handleEpochFinalized
         - event: VaultYieldAllocated(indexed uint256,indexed address,uint256)


### PR DESCRIPTION
## Summary
- update mapping to include `handleEpochProcessingStarted`
- stub vaults when missing in yield allocation handler
- register the new handler in `subgraph.yaml`
- fix missing newline at EOF

## Testing
- `yarn codegen`
- `yarn build`
- `yarn test` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684afd80bd9c832082e664abff197b77